### PR TITLE
Adding WASI fd_write implementation to support TinyGo modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,12 @@ func main() {
 		panic(err)
 	}
 
-	module, err := wapc.New(consoleLog, code, hostCall)
+	module, err := wapc.New(code, hostCall)
 	if err != nil {
 		panic(err)
 	}
+	module.SetLogger(wapc.Println) // Send __console_log calls to stardard out
+	module.SetWriter(wapc.Print) // Send WASI fd_write calls to stardard out
 	defer module.Close()
 
 	instance, err := module.Instantiate()

--- a/example/main.go
+++ b/example/main.go
@@ -21,10 +21,12 @@ func main() {
 		panic(err)
 	}
 
-	module, err := wapc.New(consoleLog, code, hostCall)
+	module, err := wapc.New(code, hostCall)
 	if err != nil {
 		panic(err)
 	}
+	module.SetLogger(wapc.Println)
+	module.SetWriter(wapc.Print)
 	defer module.Close()
 
 	instance, err := module.Instantiate()
@@ -39,10 +41,6 @@ func main() {
 	}
 
 	fmt.Println(string(result))
-}
-
-func consoleLog(msg string) {
-	fmt.Println(msg)
 }
 
 func hostCall(ctx context.Context, binding, namespace, operation string, payload []byte) ([]byte, error) {

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,6 @@ go 1.14
 require (
 	github.com/Workiva/go-datastructures v1.0.52
 	github.com/pkg/errors v0.9.1
-	github.com/stretchr/testify v1.5.1
+	github.com/stretchr/testify v1.6.1
 	github.com/wasmerio/go-ext-wasm v0.3.1
 )

--- a/go.sum
+++ b/go.sum
@@ -10,10 +10,11 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
-github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
-github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/urfave/cli/v2 v2.1.1/go.mod h1:SE9GqnLQmjVa0iPEY0f1w3ygNIYcIJ0OKPMoW2caLfQ=
 github.com/wasmerio/go-ext-wasm v0.3.1 h1:G95XP3fE2FszQSwIU+fHPBYzD0Csmd2ef33snQXNA5Q=
 github.com/wasmerio/go-ext-wasm v0.3.1/go.mod h1:VGyarTzasuS7k5KhSIGpM3tciSZlkP31Mp9VJTHMMeI=
@@ -21,3 +22,5 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/module_test.go
+++ b/module_test.go
@@ -34,7 +34,8 @@ func TestModule(t *testing.T) {
 		return []byte("test"), nil
 	}
 
-	module, err := wapc.New(consoleLog, code, hostCall)
+	module, err := wapc.New(code, hostCall)
+	module.SetLogger(consoleLog)
 	require.NoError(t, err)
 	defer module.Close()
 

--- a/pool_test.go
+++ b/pool_test.go
@@ -17,14 +17,11 @@ func TestPool(t *testing.T) {
 	code, err := ioutil.ReadFile("testdata/hello.wasm")
 	require.NoError(t, err)
 
-	consoleLog := func(msg string) {
-	}
-
 	hostCall := func(ctx context.Context, binding, namespace, operation string, payload []byte) ([]byte, error) {
 		return []byte("test"), nil
 	}
 
-	module, err := wapc.New(consoleLog, code, hostCall)
+	module, err := wapc.New(code, hostCall)
 	require.NoError(t, err)
 	defer module.Close()
 


### PR DESCRIPTION
This has a small breaking change by moving the Logger out of `New` in favor of a "secure by default" approach where you must explicitly call `SetLogger` or `SetWriter`.

Tested with:
```
(module
    ;; Import the required fd_write WASI function which will write the given io vectors to stdout
    ;; The function signature for fd_write is:
    ;; (File Descriptor, *iovs, iovs_len, nwritten) -> Returns number of bytes written
    (import "wasi_unstable" "fd_write" (func $fd_write (param i32 i32 i32 i32) (result i32)))

    (memory 1)
    (export "memory" (memory 0))

    ;; Write 'hello world\n' to memory at an offset of 8 bytes
    ;; Note the trailing newline which is required for the text to appear
    (data (i32.const 8) "hello world\n")

    (func $main (export "_start")
        ;; Creating a new io vector within linear memory
        (i32.store (i32.const 0) (i32.const 8))  ;; iov.iov_base - This is a pointer to the start of the 'hello world\n' string
        (i32.store (i32.const 4) (i32.const 12))  ;; iov.iov_len - The length of the 'hello world\n' string

        (call $fd_write
            (i32.const 1) ;; file_descriptor - 1 for stdout
            (i32.const 0) ;; *iovs - The pointer to the iov array, which is stored at memory location 0
            (i32.const 1) ;; iovs_len - We're printing 1 string stored in an iov - so one.
            (i32.const 20) ;; nwritten - A place in memory to store the number of bytes written
        )
        drop ;; Discard the number of bytes written from the top of the stack
    )
)
```