### PR TITLE
wazero: WithFeatureSignExtensionOps

### DIFF
--- a/engines/wazero/wazero.go
+++ b/engines/wazero/wazero.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/tetratelabs/wazero/wasi"
 	"io"
 	"sync/atomic"
 
 	"github.com/tetratelabs/wazero"
 	"github.com/tetratelabs/wazero/api"
+	"github.com/tetratelabs/wazero/wasi"
 
 	"github.com/wapc/wapc-go"
 )
@@ -110,7 +110,8 @@ func (s *stdout) Write(p []byte) (int, error) {
 
 // New compiles a `Module` from `code`.
 func (e *engine) New(code []byte, hostCallHandler wapc.HostCallHandler) (mod wapc.Module, err error) {
-	r := wazero.NewRuntime()
+	rc := wazero.NewRuntimeConfig().WithFeatureSignExtensionOps(true)
+	r := wazero.NewRuntimeWithConfig(rc)
 	m := &Module{runtime: r, wapcHostCallHandler: hostCallHandler}
 	m.config = wazero.NewModuleConfig().
 		WithStartFunctions(functionStart, functionInit). // Call any WASI or waPC start functions on instantiate.


### PR DESCRIPTION
Add `WithFeatureSignExtensionOps(true)` to runtime config as some of the wasm modules compiled with AssemblyScript seem to require it.

@codefromthecrypt Thanks for keeping the `wazero` package up to date with all the great changes your team has been making! I'm adding this because I was getting the following error:

```
invalid function[41]: i32.extend8_s invalid as feature sign-extension-ops is disabled
```

I'm not sure why this is considered a feature that is disabled by default. Please let me know if there are trade off/considerations for the waPC use case.