### PR TITLE
Adds context arg to allow traces to connect all lifecycle phases

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -12,9 +12,10 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/setup-go@v3
       - uses: actions/checkout@v2
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
           version: v1.29
@@ -28,8 +29,9 @@ jobs:
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           # only-new-issues: true
 
-          # Optional: if set to true then the action will use pre-installed Go.
-          # skip-go-installation: true
+          # Optional: if set to true then the all caching functionality will be complete disabled,
+          #           takes precedence over all other caching options.
+          # skip-cache: true
 
           # Optional: if set to true then the action don't cache or restore ~/go/pkg.
           # skip-pkg-cache: true

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -27,14 +26,14 @@ func main() {
 	}
 	name := os.Args[1]
 	ctx := context.Background()
-	code, err := ioutil.ReadFile("hello/hello.wasm")
+	code, err := os.ReadFile("hello/hello.wasm")
 	if err != nil {
 		panic(err)
 	}
 
 	engine := wasmer.Engine()
 
-	module, err := engine.New(code, hostCall)
+	module, err := engine.New(ctx, code, hostCall)
 	if err != nil {
 		panic(err)
 	}
@@ -42,7 +41,7 @@ func main() {
 	module.SetWriter(wapc.Print)
 	defer module.Close()
 
-	instance, err := module.Instantiate()
+	instance, err := module.Instantiate(ctx)
 	if err != nil {
 		panic(err)
 	}
@@ -83,7 +82,7 @@ Hello, WaPC!
 Alternatively you can use a `Pool` to manage a pool of instances.
 
 ```go
-	pool, err := wapc.NewPool(module, 10)
+	pool, err := wapc.NewPool(ctx, module, 10)
 	if err != nil {
 		panic(err)
 	}

--- a/engine.go
+++ b/engine.go
@@ -11,7 +11,7 @@ type (
 
 	Engine interface {
 		Name() string
-		New(code []byte, hostCallHandler HostCallHandler) (Module, error)
+		New(ctx context.Context, code []byte, hostCallHandler HostCallHandler) (Module, error)
 	}
 
 	// Module is a WebAssembly Module.
@@ -23,7 +23,7 @@ type (
 		SetWriter(writer Logger)
 
 		// Instantiate creates a single instance of the module with its own memory.
-		Instantiate() (Instance, error)
+		Instantiate(ctx context.Context) (Instance, error)
 
 		// Close releases resources from this module, ignoring any errors.
 		// Note: This should be called before after calling Instance.Close on any instances of this module.

--- a/engines/wasmer/wasmer.go
+++ b/engines/wasmer/wasmer.go
@@ -96,7 +96,7 @@ func (e *engine) Name() string {
 }
 
 // New compiles a `Module` from `code`.
-func (e *engine) New(code []byte, hostCallHandler wapc.HostCallHandler) (wapc.Module, error) {
+func (e *engine) New(_ context.Context, code []byte, hostCallHandler wapc.HostCallHandler) (wapc.Module, error) {
 	engine := wasmer.NewEngine()
 	store := wasmer.NewStore(engine)
 
@@ -124,7 +124,7 @@ func (m *Module) SetWriter(writer wapc.Logger) {
 }
 
 // Instantiate creates a single instance of the module with its own memory.
-func (m *Module) Instantiate() (wapc.Instance, error) {
+func (m *Module) Instantiate(ctx context.Context) (wapc.Instance, error) {
 	instance := Instance{
 		m: m,
 	}
@@ -157,7 +157,7 @@ func (m *Module) Instantiate() (wapc.Instance, error) {
 	for _, initFunction := range initFunctions {
 		if initFn, err := inst.Exports.GetFunction(initFunction); err == nil {
 			context := invokeContext{
-				ctx: context.Background(),
+				ctx: ctx,
 			}
 			instance.context = &context
 

--- a/engines/wasmtime/wasmtime.go
+++ b/engines/wasmtime/wasmtime.go
@@ -78,7 +78,7 @@ func (e *engine) Name() string {
 }
 
 // New compiles a `Module` from `code`.
-func (e *engine) New(code []byte, hostCallHandler wapc.HostCallHandler) (wapc.Module, error) {
+func (e *engine) New(_ context.Context, code []byte, hostCallHandler wapc.HostCallHandler) (wapc.Module, error) {
 	engine := wasmtime.NewEngine()
 	store := wasmtime.NewStore(engine)
 
@@ -109,7 +109,7 @@ func (m *Module) SetWriter(writer wapc.Logger) {
 }
 
 // Instantiate creates a single instance of the module with its own memory.
-func (m *Module) Instantiate() (wapc.Instance, error) {
+func (m *Module) Instantiate(ctx context.Context) (wapc.Instance, error) {
 	instance := Instance{
 		m: m,
 	}
@@ -152,7 +152,7 @@ func (m *Module) Instantiate() (wapc.Instance, error) {
 	for _, initFunction := range initFunctions {
 		if initFn := inst.GetFunc(m.store, initFunction); initFn != nil {
 			context := invokeContext{
-				ctx: context.Background(),
+				ctx: ctx,
 			}
 			instance.context = &context
 

--- a/example/main.go
+++ b/example/main.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"strings"
@@ -50,14 +49,14 @@ func main() {
 	settings := cli()
 
 	ctx := context.Background()
-	code, err := ioutil.ReadFile(settings.ModulePath)
+	code, err := os.ReadFile(settings.ModulePath)
 	if err != nil {
 		panic(err)
 	}
 
 	engine := wasmtime.Engine()
 
-	module, err := engine.New(code, hostCall)
+	module, err := engine.New(ctx, code, hostCall)
 	if err != nil {
 		panic(err)
 	}
@@ -65,7 +64,7 @@ func main() {
 	module.SetWriter(wapc.Print)
 	defer module.Close()
 
-	instance, err := module.Instantiate()
+	instance, err := module.Instantiate(ctx)
 	if err != nil {
 		panic(err)
 	}
@@ -79,7 +78,7 @@ func main() {
 	fmt.Println(string(result))
 }
 
-func hostCall(ctx context.Context, binding, namespace, operation string, payload []byte) ([]byte, error) {
+func hostCall(_ context.Context, binding, namespace, operation string, payload []byte) ([]byte, error) {
 	log.Println("host callback")
 	log.Printf("binding: %s\n", binding)
 	log.Printf("namespace: %s\n", namespace)

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,6 @@ go 1.17
 require (
 	github.com/Workiva/go-datastructures v1.0.53
 	github.com/bytecodealliance/wasmtime-go v0.35.0
-	github.com/tetratelabs/wazero v0.0.0-20220401224236-2664b1eb62a2
+	github.com/tetratelabs/wazero v0.0.0-20220419085257-45ccab589bc8
 	github.com/wasmerio/wasmer-go v1.0.4
 )
-
-require github.com/twitchyliquid64/golang-asm v0.15.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,12 +10,10 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/tetratelabs/wazero v0.0.0-20220401224236-2664b1eb62a2 h1:T6qVU9nmdy2pQ82ml5iiv0cGNLCzAQ2VNG+U3bQEniQ=
-github.com/tetratelabs/wazero v0.0.0-20220401224236-2664b1eb62a2/go.mod h1:jF+njZWLD70K/xB02hWVz5aQ2m+RCfFjIUJi44t9zOo=
+github.com/tetratelabs/wazero v0.0.0-20220419085257-45ccab589bc8 h1:8DehcP+bZ/uUAR+ssNpIy3sZW3KKTL6V3KYANwXG2E4=
+github.com/tetratelabs/wazero v0.0.0-20220419085257-45ccab589bc8/go.mod h1:Y4X/zO4sC2dJjZG9GDYNRbJGogfqFYJY/BbyKlOxXGI=
 github.com/tinylib/msgp v1.1.5/go.mod h1:eQsjooMTnV42mHu917E26IogZ2930nFyBQdofk10Udg=
 github.com/ttacon/chalk v0.0.0-20160626202418-22c06c80ed31/go.mod h1:onvgF043R+lC5RZ8IT9rBXDaEDnpnw/Cl+HFiw+v/7Q=
-github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS4MhqMhdFk5YI=
-github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=
 github.com/wasmerio/wasmer-go v1.0.4 h1:MnqHoOGfiQ8MMq2RF6wyCeebKOe84G88h5yv+vmxJgs=
 github.com/wasmerio/wasmer-go v1.0.4/go.mod h1:0gzVdSfg6pysA6QVp6iVRPTagC6Wq9pOE8J86WKb2Fk=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/pool.go
+++ b/pool.go
@@ -1,6 +1,7 @@
 package wapc
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"time"
@@ -19,11 +20,11 @@ type (
 
 // NewPool takes in compiled WASM module and a size and returns a pool
 // containing `size` instances of that module.
-func NewPool(module Module, size uint64) (*Pool, error) {
+func NewPool(ctx context.Context, module Module, size uint64) (*Pool, error) {
 	rb := queue.NewRingBuffer(size)
 	instances := make([]Instance, size)
 	for i := uint64(0); i < size; i++ {
-		inst, err := module.Instantiate()
+		inst, err := module.Instantiate(ctx)
 		if err != nil {
 			return nil, err
 		}

--- a/pool_test.go
+++ b/pool_test.go
@@ -2,7 +2,7 @@ package wapc_test
 
 import (
 	"context"
-	"io/ioutil"
+	"os"
 	"testing"
 	"time"
 
@@ -21,7 +21,7 @@ func TestGuestsWithPool(t *testing.T) {
 			for l, p := range lang {
 				t.Run("Module testing with "+l+" Guest", func(t *testing.T) {
 					// Read .wasm file
-					b, err := ioutil.ReadFile("testdata/" + p)
+					b, err := os.ReadFile("testdata/" + p)
 					if err != nil {
 						t.Errorf("Unable to open test file - %s", err)
 					}
@@ -31,7 +31,7 @@ func TestGuestsWithPool(t *testing.T) {
 					payload := []byte("Testing")
 
 					// Create new module with a callback function
-					m, err := engine.New(b, func(context.Context, string, string, string, []byte) ([]byte, error) {
+					m, err := engine.New(ctx, b, func(context.Context, string, string, string, []byte) ([]byte, error) {
 						callbackCh <- struct{}{}
 						return []byte(""), nil
 					})
@@ -40,20 +40,20 @@ func TestGuestsWithPool(t *testing.T) {
 					}
 					defer m.Close()
 
-					p, err := wapc.NewPool(m, 10)
+					p, err := wapc.NewPool(ctx, m, 10)
 					if err != nil {
 						t.Errorf("Error creating module pool - %s", err)
 					}
 					defer p.Close()
 
-					i, err := p.Get(time.Duration(10 * time.Second))
+					i, err := p.Get(10 * time.Second)
 					if err != nil {
 						t.Errorf("Error unable to fetch instance from pool - %s", err)
 					}
 
 					t.Run("Call Successful Function", func(t *testing.T) {
 						// Call echo function
-						r, err := i.Invoke(context.Background(), "echo", payload)
+						r, err := i.Invoke(ctx, "echo", payload)
 						if err != nil {
 							t.Errorf("Unexpected error when calling wasm module - %s", err)
 						}
@@ -74,14 +74,14 @@ func TestGuestsWithPool(t *testing.T) {
 
 					t.Run("Call Failing Function", func(t *testing.T) {
 						// Call nope function
-						_, err := i.Invoke(context.Background(), "nope", payload)
+						_, err := i.Invoke(ctx, "nope", payload)
 						if err == nil {
 							t.Errorf("Expected error when calling failing function, got nil")
 						}
 					})
 
 					t.Run("Call Unregistered Function", func(t *testing.T) {
-						_, err := i.Invoke(context.Background(), "404", payload)
+						_, err := i.Invoke(ctx, "404", payload)
 						if err == nil {
 							t.Errorf("Expected error when calling unregistered function, got nil")
 						}


### PR DESCRIPTION
Before, a distributed trace couldn't include all phases of wapc. For
example, the `New` function implies a fair amount of time dependending
on implementation as that's when compilation can occur. Similarly, the
act of instantiation not only can take time, but also invokes start
functions. This change ensures `context.Context` flows through all these
steps. That way, instrumentation such as opentelemetry can connect
traces such that they are viewable on tools like Zipkin, and fully
account for what's going on in Wasm.