### PR TITLE
Adds remaining context propagation

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -17,30 +17,30 @@ type (
 	// Module is a WebAssembly Module.
 	Module interface {
 		// SetLogger sets the waPC logger for `__console_log` function calls.
-		SetLogger(logger Logger)
+		SetLogger(Logger)
 
 		// SetWriter sets the writer for WASI `fd_write` calls to stdout (file descriptor 1).
-		SetWriter(writer Logger)
+		SetWriter(Logger)
 
 		// Instantiate creates a single instance of the module with its own memory.
-		Instantiate(ctx context.Context) (Instance, error)
+		Instantiate(context.Context) (Instance, error)
 
 		// Close releases resources from this module, ignoring any errors.
 		// Note: This should be called before after calling Instance.Close on any instances of this module.
-		Close()
+		Close(context.Context)
 	}
 
 	// Instance is an instantiated Module
 	Instance interface {
 		// MemorySize is the size in bytes of the memory available to this Instance.
-		MemorySize() uint32
+		MemorySize(context.Context) uint32
 
 		// Invoke calls `operation` with `payload` on the module and returns a byte slice payload.
 		Invoke(ctx context.Context, operation string, payload []byte) ([]byte, error)
 
 		// Close releases resources from this instance, ignoring any errors.
 		// Note: This should be called before calling Module.Close.
-		Close()
+		Close(context.Context)
 	}
 )
 

--- a/engine_test.go
+++ b/engine_test.go
@@ -49,7 +49,7 @@ func TestGuests(t *testing.T) {
 					if err != nil {
 						t.Errorf("Error creating module - %s", err)
 					}
-					defer m.Close()
+					defer m.Close(ctx)
 
 					// Set loggers and writers
 					m.SetLogger(wapc.Println)
@@ -60,7 +60,7 @@ func TestGuests(t *testing.T) {
 					if err != nil {
 						t.Errorf("Error instantiating module - %s", err)
 					}
-					defer i.Close()
+					defer i.Close(ctx)
 
 					t.Run("Call Successful Function", func(t *testing.T) {
 						// Call echo function
@@ -133,7 +133,7 @@ func TestModule(t *testing.T) {
 			if err != nil {
 				t.Errorf("Error creating module - %s", err)
 			}
-			defer m.Close()
+			defer m.Close(ctx)
 
 			// Set loggers and writers
 			m.SetLogger(wapc.Println)
@@ -144,13 +144,13 @@ func TestModule(t *testing.T) {
 			if err != nil {
 				t.Errorf("Error instantiating module - %s", err)
 			}
-			defer i.Close()
+			defer i.Close(ctx)
 
 			t.Run("Check MemorySize", func(t *testing.T) {
 				// Verify implementations didn't mistake size in bytes for page count.
 				expectedMemorySize := uint32(65536) // 1 page
-				if i.MemorySize() != expectedMemorySize {
-					t.Errorf("Unexpected memory size, got %d, expected %d", i.MemorySize(), expectedMemorySize)
+				if i.MemorySize(ctx) != expectedMemorySize {
+					t.Errorf("Unexpected memory size, got %d, expected %d", i.MemorySize(ctx), expectedMemorySize)
 				}
 			})
 
@@ -167,7 +167,7 @@ func TestModule(t *testing.T) {
 				}
 			})
 
-			i.Close()
+			i.Close(ctx)
 
 			t.Run("Call Function with Closed Instance", func(t *testing.T) {
 				// Call echo function

--- a/engines/wasmer/wasmer.go
+++ b/engines/wasmer/wasmer.go
@@ -515,7 +515,7 @@ func (i *Instance) wasiRuntime() map[string]wasmer.IntoExtern {
 }
 
 // MemorySize returns the memory length of the underlying instance.
-func (i *Instance) MemorySize() uint32 {
+func (i *Instance) MemorySize(context.Context) uint32 {
 	return uint32(i.mem.DataSize())
 }
 
@@ -552,7 +552,7 @@ func (i *Instance) Invoke(ctx context.Context, operation string, payload []byte)
 }
 
 // Close closes the single instance.  This should be called before calling `Close` on the Module itself.
-func (i *Instance) Close() {
+func (i *Instance) Close(context.Context) {
 	// Explicitly release references on wasmer types so they can be GC'ed.
 	i.inst = nil
 	i.mem = nil
@@ -571,7 +571,7 @@ func (i *Instance) Close() {
 }
 
 // Close closes the module.  This should be called after calling `Close` on any instances that were created.
-func (m *Module) Close() {
+func (m *Module) Close(context.Context) {
 	// Explicitly release references on wasmer types so they can be GC'ed.
 	m.module = nil
 	m.store = nil

--- a/engines/wasmtime/wasmtime.go
+++ b/engines/wasmtime/wasmtime.go
@@ -400,7 +400,7 @@ func (i *Instance) wapcRuntime() map[string]*wasmtime.Func {
 }
 
 // MemorySize returns the memory length of the underlying instance.
-func (i *Instance) MemorySize() uint32 {
+func (i *Instance) MemorySize(context.Context) uint32 {
 	return uint32(i.mem.DataSize(i.m.store))
 }
 
@@ -437,7 +437,7 @@ func (i *Instance) Invoke(ctx context.Context, operation string, payload []byte)
 }
 
 // Close closes the single instance.  This should be called before calling `Close` on the Module itself.
-func (i *Instance) Close() {
+func (i *Instance) Close(context.Context) {
 	// Explicitly release references on wasmtime types so they can be GC'ed.
 	i.inst = nil
 	i.mem = nil
@@ -455,7 +455,7 @@ func (i *Instance) Close() {
 }
 
 // Close closes the module.  This should be called after calling `Close` on any instances that were created.
-func (m *Module) Close() {
+func (m *Module) Close(context.Context) {
 	// Explicitly release references on wasmtime types so they can be GC'ed.
 	m.module = nil
 	m.store = nil

--- a/example/main.go
+++ b/example/main.go
@@ -62,13 +62,13 @@ func main() {
 	}
 	module.SetLogger(wapc.Println)
 	module.SetWriter(wapc.Print)
-	defer module.Close()
+	defer module.Close(ctx)
 
 	instance, err := module.Instantiate(ctx)
 	if err != nil {
 		panic(err)
 	}
-	defer instance.Close()
+	defer instance.Close(ctx)
 
 	result, err := instance.Invoke(ctx, settings.WaPCFunction, []byte(settings.Message))
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,6 @@ go 1.17
 require (
 	github.com/Workiva/go-datastructures v1.0.53
 	github.com/bytecodealliance/wasmtime-go v0.35.0
-	github.com/tetratelabs/wazero v0.0.0-20220419085257-45ccab589bc8
+	github.com/tetratelabs/wazero v0.0.0-20220425003459-ad61d9a6ff43
 	github.com/wasmerio/wasmer-go v1.0.4
 )

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/tetratelabs/wazero v0.0.0-20220419085257-45ccab589bc8 h1:8DehcP+bZ/uUAR+ssNpIy3sZW3KKTL6V3KYANwXG2E4=
-github.com/tetratelabs/wazero v0.0.0-20220419085257-45ccab589bc8/go.mod h1:Y4X/zO4sC2dJjZG9GDYNRbJGogfqFYJY/BbyKlOxXGI=
+github.com/tetratelabs/wazero v0.0.0-20220425003459-ad61d9a6ff43 h1:o/PS34ksCpw72GtxUKad1jDMPsgGn6zVRG0BFIOUrsU=
+github.com/tetratelabs/wazero v0.0.0-20220425003459-ad61d9a6ff43/go.mod h1:Y4X/zO4sC2dJjZG9GDYNRbJGogfqFYJY/BbyKlOxXGI=
 github.com/tinylib/msgp v1.1.5/go.mod h1:eQsjooMTnV42mHu917E26IogZ2930nFyBQdofk10Udg=
 github.com/ttacon/chalk v0.0.0-20160626202418-22c06c80ed31/go.mod h1:onvgF043R+lC5RZ8IT9rBXDaEDnpnw/Cl+HFiw+v/7Q=
 github.com/wasmerio/wasmer-go v1.0.4 h1:MnqHoOGfiQ8MMq2RF6wyCeebKOe84G88h5yv+vmxJgs=

--- a/pool.go
+++ b/pool.go
@@ -79,10 +79,10 @@ func (p *Pool) Return(inst Instance) error {
 }
 
 // Close closes down all the instances contained by the pool.
-func (p *Pool) Close() {
+func (p *Pool) Close(ctx context.Context) {
 	p.rb.Dispose()
 
 	for _, inst := range p.instances {
-		inst.Close()
+		inst.Close(ctx)
 	}
 }

--- a/pool_test.go
+++ b/pool_test.go
@@ -38,13 +38,13 @@ func TestGuestsWithPool(t *testing.T) {
 					if err != nil {
 						t.Errorf("Error creating module - %s", err)
 					}
-					defer m.Close()
+					defer m.Close(ctx)
 
 					p, err := wapc.NewPool(ctx, m, 10)
 					if err != nil {
 						t.Errorf("Error creating module pool - %s", err)
 					}
-					defer p.Close()
+					defer p.Close(ctx)
 
 					i, err := p.Get(10 * time.Second)
 					if err != nil {


### PR DESCRIPTION
This propagates context for the last remaining operations, notably
memory ops and close. These allow tracing to answer questions like
"which code exited the module?" or "which code grew memory?"

Note: While getting the memory size is questionable value to add
context on its own, it helps for consistency as all non-constant
ops otherwise are context aware.