### PR TITLE
wazero: switches to Wasm 2.0 flag

### DIFF
--- a/engines/wazero/wazero.go
+++ b/engines/wazero/wazero.go
@@ -47,12 +47,12 @@ type (
 		wapcHostCallHandler wapc.HostCallHandler
 
 		runtime wazero.Runtime
-		code    *wazero.CompiledCode
+		code    wazero.CompiledCode
 
 		instanceCounter uint64
 
 		wasi, assemblyScript, wapc api.Module
-		config                     *wazero.ModuleConfig
+		config                     wazero.ModuleConfig
 
 		// closed is atomically updated to ensure Close is only invoked once.
 		closed uint32
@@ -110,7 +110,7 @@ func (s *stdout) Write(p []byte) (int, error) {
 
 // New compiles a `Module` from `code`.
 func (e *engine) New(ctx context.Context, code []byte, hostCallHandler wapc.HostCallHandler) (mod wapc.Module, err error) {
-	rc := wazero.NewRuntimeConfig().WithFeatureSignExtensionOps(true)
+	rc := wazero.NewRuntimeConfig().WithWasmCore2()
 	r := wazero.NewRuntimeWithConfig(rc)
 	m := &Module{runtime: r, wapcHostCallHandler: hostCallHandler}
 	m.config = wazero.NewModuleConfig().

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,6 @@ go 1.17
 require (
 	github.com/Workiva/go-datastructures v1.0.53
 	github.com/bytecodealliance/wasmtime-go v0.35.0
-	github.com/tetratelabs/wazero v0.0.0-20220425003459-ad61d9a6ff43
+	github.com/tetratelabs/wazero v0.0.0-20220503023851-72f16d21eb4a
 	github.com/wasmerio/wasmer-go v1.0.4
 )

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/tetratelabs/wazero v0.0.0-20220425003459-ad61d9a6ff43 h1:o/PS34ksCpw72GtxUKad1jDMPsgGn6zVRG0BFIOUrsU=
-github.com/tetratelabs/wazero v0.0.0-20220425003459-ad61d9a6ff43/go.mod h1:Y4X/zO4sC2dJjZG9GDYNRbJGogfqFYJY/BbyKlOxXGI=
+github.com/tetratelabs/wazero v0.0.0-20220503023851-72f16d21eb4a h1:k9hVyZcNAVhiVp8YE6r2Trji8HD8CHleaQhqHZDXaEM=
+github.com/tetratelabs/wazero v0.0.0-20220503023851-72f16d21eb4a/go.mod h1:Y4X/zO4sC2dJjZG9GDYNRbJGogfqFYJY/BbyKlOxXGI=
 github.com/tinylib/msgp v1.1.5/go.mod h1:eQsjooMTnV42mHu917E26IogZ2930nFyBQdofk10Udg=
 github.com/ttacon/chalk v0.0.0-20160626202418-22c06c80ed31/go.mod h1:onvgF043R+lC5RZ8IT9rBXDaEDnpnw/Cl+HFiw+v/7Q=
 github.com/wasmerio/wasmer-go v1.0.4 h1:MnqHoOGfiQ8MMq2RF6wyCeebKOe84G88h5yv+vmxJgs=


### PR DESCRIPTION
Since WebAssembly 2.0 is defined, albeit draft, we can opt in to
something relatively stable as opposed to picking feature by feature.
