### PR TITLE
Makes Close return error and fixes some safety issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,13 @@ func main() {
 	}
 	module.SetLogger(wapc.Println)
 	module.SetWriter(wapc.Print)
-	defer module.Close()
+	defer module.Close(ctx)
 
 	instance, err := module.Instantiate(ctx)
 	if err != nil {
 		panic(err)
 	}
-	defer instance.Close()
+	defer instance.Close(ctx)
 
 	result, err := instance.Invoke(ctx, "hello", []byte(name))
 	if err != nil {
@@ -86,7 +86,7 @@ Alternatively you can use a `Pool` to manage a pool of instances.
 	if err != nil {
 		panic(err)
 	}
-	defer pool.Close()
+	defer pool.Close(ctx)
 
 	for i := 0; i < 100; i++ {
 		instance, err := pool.Get(10 * time.Millisecond)
@@ -118,7 +118,7 @@ Here are the supported `wapc.Engine` implementations, in alphabetical order:
 |:-----------:|:-----------------:|:-------:|
 | wasmer-go   |`wasmer.Engine()`  |[github.com/wasmerio/wasmer-go](https://pkg.go.dev/github.com/wasmerio/wasmer-go)|
 | wasmtime-go |`wasmtime.Engine()`|[github.com/bytecodealliance/wasmtime-go](https://pkg.go.dev/github.com/bytecodealliance/wasmtime-go)|
-| wazero      |`wazero.Engine()`  |[github.com/tetratelabs/wazero](https://pkg.go.dev/github.com/tetratelabs/wazero)|
+| wazero      |`wazero.Engine()`  |[github.com/tetratelabs/wazero](https://wazero.io)|
 
 ### Differences with [wapc-rs](https://github.com/wapc/wapc-rs) (Rust)
 

--- a/engine.go
+++ b/engine.go
@@ -25,9 +25,9 @@ type (
 		// Instantiate creates a single instance of the module with its own memory.
 		Instantiate(context.Context) (Instance, error)
 
-		// Close releases resources from this module, ignoring any errors.
+		// Close releases resources from this module, returning the first error encountered.
 		// Note: This should be called before after calling Instance.Close on any instances of this module.
-		Close(context.Context)
+		Close(context.Context) error
 	}
 
 	// Instance is an instantiated Module
@@ -38,9 +38,9 @@ type (
 		// Invoke calls `operation` with `payload` on the module and returns a byte slice payload.
 		Invoke(ctx context.Context, operation string, payload []byte) ([]byte, error)
 
-		// Close releases resources from this instance, ignoring any errors.
+		// Close releases resources from this instance, returning the first error encountered.
 		// Note: This should be called before calling Module.Close.
-		Close(context.Context)
+		Close(context.Context) error
 	}
 )
 

--- a/engines/wasmtime/wasmtime.go
+++ b/engines/wasmtime/wasmtime.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync/atomic"
 
 	"github.com/bytecodealliance/wasmtime-go"
 
@@ -23,6 +24,9 @@ type (
 		engine *wasmtime.Engine
 		store  *wasmtime.Store
 		module *wasmtime.Module
+
+		// closed is atomically updated to ensure Close is only invoked once.
+		closed uint32
 	}
 
 	// Instance is a single instantiation of a module with its own memory.
@@ -48,6 +52,9 @@ type (
 
 		// AssemblyScript functions
 		abort *wasmtime.Func
+
+		// closed is atomically updated to ensure Close is only invoked once.
+		closed uint32
 	}
 
 	invokeContext struct {
@@ -110,6 +117,11 @@ func (m *Module) SetWriter(writer wapc.Logger) {
 
 // Instantiate creates a single instance of the module with its own memory.
 func (m *Module) Instantiate(ctx context.Context) (wapc.Instance, error) {
+	if closed := atomic.LoadUint32(&m.closed); closed != 0 {
+		return nil, errors.New("cannot Instantiate when a module is closed")
+	}
+	// Note: There's still a race below, even if the above check is still useful.
+
 	instance := Instance{
 		m: m,
 	}
@@ -406,10 +418,10 @@ func (i *Instance) MemorySize(context.Context) uint32 {
 
 // Invoke calls `operation` with `payload` on the module and returns a byte slice payload.
 func (i *Instance) Invoke(ctx context.Context, operation string, payload []byte) ([]byte, error) {
-	// Make sure instance isn't closed to avoid panics
-	if i.inst == nil {
+	if closed := atomic.LoadUint32(&i.closed); closed != 0 {
 		return nil, fmt.Errorf("error invoking guest with closed instance")
 	}
+	// Note: There's still a race below, even if the above check is still useful.
 
 	context := invokeContext{
 		ctx:       ctx,
@@ -437,8 +449,12 @@ func (i *Instance) Invoke(ctx context.Context, operation string, payload []byte)
 }
 
 // Close closes the single instance.  This should be called before calling `Close` on the Module itself.
-func (i *Instance) Close(context.Context) {
-	// Explicitly release references on wasmtime types so they can be GC'ed.
+func (i *Instance) Close(context.Context) error {
+	if !atomic.CompareAndSwapUint32(&i.closed, 0, 1) {
+		return nil
+	}
+
+	// Explicitly release references on wasmtime types, so they can be GC'ed.
 	i.inst = nil
 	i.mem = nil
 	i.context = nil
@@ -452,12 +468,21 @@ func (i *Instance) Close(context.Context) {
 	i.hostError = nil
 	i.consoleLog = nil
 	i.abort = nil
+	return nil // wasmtime only closes via finalizer
 }
 
 // Close closes the module.  This should be called after calling `Close` on any instances that were created.
-func (m *Module) Close(context.Context) {
-	// Explicitly release references on wasmtime types so they can be GC'ed.
+func (m *Module) Close(context.Context) error {
+	if !atomic.CompareAndSwapUint32(&m.closed, 0, 1) {
+		return nil
+	}
+
+	// Explicitly release references on wasmtime types, so they can be GC'ed.
 	m.module = nil
-	m.store = nil
+	if store := m.store; store != nil {
+		store.GC()
+		m.store = nil
+	}
 	m.engine = nil
+	return nil // wasmtime only closes via finalizer
 }

--- a/engines/wazero/wazero.go
+++ b/engines/wazero/wazero.go
@@ -110,7 +110,7 @@ func (s *stdout) Write(p []byte) (int, error) {
 
 // New compiles a `Module` from `code`.
 func (e *engine) New(ctx context.Context, source []byte, hostCallHandler wapc.HostCallHandler) (mod wapc.Module, err error) {
-	rc := wazero.NewRuntimeConfig().WithFeatureSignExtensionOps(true)
+	rc := wazero.NewRuntimeConfig().WithWasmCore2()
 	r := wazero.NewRuntimeWithConfig(rc)
 	m := &Module{runtime: r, wapcHostCallHandler: hostCallHandler}
 	m.config = wazero.NewModuleConfig().

--- a/engines/wazero/wazero.go
+++ b/engines/wazero/wazero.go
@@ -46,13 +46,13 @@ type (
 		// wapcHostCallHandler is the value of wapcHost.callHandler
 		wapcHostCallHandler wapc.HostCallHandler
 
-		runtime wazero.Runtime
-		code    *wazero.CompiledCode
+		runtime  wazero.Runtime
+		compiled wazero.CompiledModule
 
 		instanceCounter uint64
 
 		wasi, assemblyScript, wapc api.Module
-		config                     *wazero.ModuleConfig
+		config                     wazero.ModuleConfig
 
 		// closed is atomically updated to ensure Close is only invoked once.
 		closed uint32
@@ -109,7 +109,7 @@ func (s *stdout) Write(p []byte) (int, error) {
 }
 
 // New compiles a `Module` from `code`.
-func (e *engine) New(ctx context.Context, code []byte, hostCallHandler wapc.HostCallHandler) (mod wapc.Module, err error) {
+func (e *engine) New(ctx context.Context, source []byte, hostCallHandler wapc.HostCallHandler) (mod wapc.Module, err error) {
 	rc := wazero.NewRuntimeConfig().WithFeatureSignExtensionOps(true)
 	r := wazero.NewRuntimeWithConfig(rc)
 	m := &Module{runtime: r, wapcHostCallHandler: hostCallHandler}
@@ -133,7 +133,7 @@ func (e *engine) New(ctx context.Context, code []byte, hostCallHandler wapc.Host
 		return
 	}
 
-	if m.code, err = r.CompileModule(ctx, code); err != nil {
+	if m.compiled, err = r.CompileModule(ctx, source, wazero.NewCompileConfig()); err != nil {
 		mod.Close(ctx)
 		return
 	}
@@ -332,7 +332,7 @@ func (m *Module) Instantiate(ctx context.Context) (wapc.Instance, error) {
 
 	moduleName := fmt.Sprintf("%d", atomic.AddUint64(&m.instanceCounter, 1))
 
-	module, err := m.runtime.InstantiateModuleWithConfig(ctx, m.code, m.config.WithName(moduleName))
+	module, err := m.runtime.InstantiateModule(ctx, m.compiled, m.config.WithName(moduleName))
 	if err != nil {
 		return nil, err
 	}
@@ -396,37 +396,50 @@ func (i *Instance) Invoke(ctx context.Context, operation string, payload []byte)
 }
 
 // Close implements the same method as documented on wapc.Instance.
-func (i *Instance) Close(ctx context.Context) {
+func (i *Instance) Close(ctx context.Context) error{
 	if !atomic.CompareAndSwapUint32(&i.closed, 0, 1) {
-		return
+		return nil
 	}
-	_ = i.m.Close(ctx)
+	return i.m.Close(ctx)
 }
 
 // Close implements the same method as documented on wapc.Module.
-func (m *Module) Close(ctx context.Context) {
+func (m *Module) Close(ctx context.Context) (err error) {
 	if !atomic.CompareAndSwapUint32(&m.closed, 0, 1) {
 		return
 	}
 
 	// TODO m.engine.Close() https://github.com/tetratelabs/wazero/issues/382
 	if wapc := m.wapc; wapc != nil {
-		_ = wapc.Close(ctx)
+		if e := wapc.Close(ctx); e != nil && err != nil {
+			err = e // first error
+		}
 		m.wapc = nil
 	}
 
 	if env := m.assemblyScript; env != nil {
-		_ = env.Close(ctx)
+		if e := env.Close(ctx); e != nil && err != nil {
+			err = e // first error
+		}
 		m.assemblyScript = nil
 	}
 
 	if wasi := m.wasi; wasi != nil {
-		_ = wasi.Close(ctx)
+		if e := wasi.Close(ctx); e != nil && err != nil {
+			err = e // first error
+		}
 		m.wasi = nil
 	}
 
-	m.code = nil
+	if compiled := m.compiled; compiled != nil {
+		if e := compiled.Close(ctx); e != nil && err != nil {
+			err = e // first error
+		}
+		m.compiled = nil
+	}
+
 	m.runtime = nil
+	return
 }
 
 // requireReadString is a convenience function that casts requireRead

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,6 @@ go 1.17
 require (
 	github.com/Workiva/go-datastructures v1.0.53
 	github.com/bytecodealliance/wasmtime-go v0.35.0
-	github.com/tetratelabs/wazero v0.0.0-20220511011221-c50c121a48d2
+	github.com/tetratelabs/wazero v0.0.0-20220516235056-c815060196bb
 	github.com/wasmerio/wasmer-go v1.0.4
 )

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,6 @@ go 1.17
 require (
 	github.com/Workiva/go-datastructures v1.0.53
 	github.com/bytecodealliance/wasmtime-go v0.35.0
-	github.com/tetratelabs/wazero v0.0.0-20220425003459-ad61d9a6ff43
+	github.com/tetratelabs/wazero v0.0.0-20220509065650-96bc7c84624e
 	github.com/wasmerio/wasmer-go v1.0.4
 )

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,6 @@ go 1.17
 require (
 	github.com/Workiva/go-datastructures v1.0.53
 	github.com/bytecodealliance/wasmtime-go v0.35.0
-	github.com/tetratelabs/wazero v0.0.0-20220510030018-8dd797e108db
+	github.com/tetratelabs/wazero v0.0.0-20220511011221-c50c121a48d2
 	github.com/wasmerio/wasmer-go v1.0.4
 )

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,6 @@ go 1.17
 require (
 	github.com/Workiva/go-datastructures v1.0.53
 	github.com/bytecodealliance/wasmtime-go v0.35.0
-	github.com/tetratelabs/wazero v0.0.0-20220509065650-96bc7c84624e
+	github.com/tetratelabs/wazero v0.0.0-20220510030018-8dd797e108db
 	github.com/wasmerio/wasmer-go v1.0.4
 )

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/tetratelabs/wazero v0.0.0-20220510030018-8dd797e108db h1:HQDOsOFGBdhO6c163iIT0NEod1uenfxTLJWkaUTD42k=
-github.com/tetratelabs/wazero v0.0.0-20220510030018-8dd797e108db/go.mod h1:Y4X/zO4sC2dJjZG9GDYNRbJGogfqFYJY/BbyKlOxXGI=
+github.com/tetratelabs/wazero v0.0.0-20220511011221-c50c121a48d2 h1:/vJF4Dcrk/WfeqIsEUHol/UCqPRUpn2BPiIhL4LveN4=
+github.com/tetratelabs/wazero v0.0.0-20220511011221-c50c121a48d2/go.mod h1:Y4X/zO4sC2dJjZG9GDYNRbJGogfqFYJY/BbyKlOxXGI=
 github.com/tinylib/msgp v1.1.5/go.mod h1:eQsjooMTnV42mHu917E26IogZ2930nFyBQdofk10Udg=
 github.com/ttacon/chalk v0.0.0-20160626202418-22c06c80ed31/go.mod h1:onvgF043R+lC5RZ8IT9rBXDaEDnpnw/Cl+HFiw+v/7Q=
 github.com/wasmerio/wasmer-go v1.0.4 h1:MnqHoOGfiQ8MMq2RF6wyCeebKOe84G88h5yv+vmxJgs=

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/tetratelabs/wazero v0.0.0-20220511011221-c50c121a48d2 h1:/vJF4Dcrk/WfeqIsEUHol/UCqPRUpn2BPiIhL4LveN4=
-github.com/tetratelabs/wazero v0.0.0-20220511011221-c50c121a48d2/go.mod h1:Y4X/zO4sC2dJjZG9GDYNRbJGogfqFYJY/BbyKlOxXGI=
+github.com/tetratelabs/wazero v0.0.0-20220516235056-c815060196bb h1:9Id4NB7BH4iJeocqIQPXmF+NNMaM0dQ9NAuAPVKmyAQ=
+github.com/tetratelabs/wazero v0.0.0-20220516235056-c815060196bb/go.mod h1:Y4X/zO4sC2dJjZG9GDYNRbJGogfqFYJY/BbyKlOxXGI=
 github.com/tinylib/msgp v1.1.5/go.mod h1:eQsjooMTnV42mHu917E26IogZ2930nFyBQdofk10Udg=
 github.com/ttacon/chalk v0.0.0-20160626202418-22c06c80ed31/go.mod h1:onvgF043R+lC5RZ8IT9rBXDaEDnpnw/Cl+HFiw+v/7Q=
 github.com/wasmerio/wasmer-go v1.0.4 h1:MnqHoOGfiQ8MMq2RF6wyCeebKOe84G88h5yv+vmxJgs=

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/tetratelabs/wazero v0.0.0-20220509065650-96bc7c84624e h1:ZITQpzJuxUcDmy1c1MxU3XMO2SH3j9J0d7F9gyrySJs=
-github.com/tetratelabs/wazero v0.0.0-20220509065650-96bc7c84624e/go.mod h1:Y4X/zO4sC2dJjZG9GDYNRbJGogfqFYJY/BbyKlOxXGI=
+github.com/tetratelabs/wazero v0.0.0-20220510030018-8dd797e108db h1:HQDOsOFGBdhO6c163iIT0NEod1uenfxTLJWkaUTD42k=
+github.com/tetratelabs/wazero v0.0.0-20220510030018-8dd797e108db/go.mod h1:Y4X/zO4sC2dJjZG9GDYNRbJGogfqFYJY/BbyKlOxXGI=
 github.com/tinylib/msgp v1.1.5/go.mod h1:eQsjooMTnV42mHu917E26IogZ2930nFyBQdofk10Udg=
 github.com/ttacon/chalk v0.0.0-20160626202418-22c06c80ed31/go.mod h1:onvgF043R+lC5RZ8IT9rBXDaEDnpnw/Cl+HFiw+v/7Q=
 github.com/wasmerio/wasmer-go v1.0.4 h1:MnqHoOGfiQ8MMq2RF6wyCeebKOe84G88h5yv+vmxJgs=

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/tetratelabs/wazero v0.0.0-20220425003459-ad61d9a6ff43 h1:o/PS34ksCpw72GtxUKad1jDMPsgGn6zVRG0BFIOUrsU=
-github.com/tetratelabs/wazero v0.0.0-20220425003459-ad61d9a6ff43/go.mod h1:Y4X/zO4sC2dJjZG9GDYNRbJGogfqFYJY/BbyKlOxXGI=
+github.com/tetratelabs/wazero v0.0.0-20220509065650-96bc7c84624e h1:ZITQpzJuxUcDmy1c1MxU3XMO2SH3j9J0d7F9gyrySJs=
+github.com/tetratelabs/wazero v0.0.0-20220509065650-96bc7c84624e/go.mod h1:Y4X/zO4sC2dJjZG9GDYNRbJGogfqFYJY/BbyKlOxXGI=
 github.com/tinylib/msgp v1.1.5/go.mod h1:eQsjooMTnV42mHu917E26IogZ2930nFyBQdofk10Udg=
 github.com/ttacon/chalk v0.0.0-20160626202418-22c06c80ed31/go.mod h1:onvgF043R+lC5RZ8IT9rBXDaEDnpnw/Cl+HFiw+v/7Q=
 github.com/wasmerio/wasmer-go v1.0.4 h1:MnqHoOGfiQ8MMq2RF6wyCeebKOe84G88h5yv+vmxJgs=


### PR DESCRIPTION
This makes Close more safe in the non-wazero impls by using atomic
instead of field check to see if a function should proceed.

This also makes "error ignoring" a decision of the caller of `Close` vs
an implicit decision inside an implementation.
