### PR TITLE
Switches example to wazero and introduces build tags for CGO engines

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -14,12 +14,15 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: 1.17
 
     - name: Test
       run: go test -v ./...
+
+    - name: Run Example
+      run: go run example/main.go waPC!

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is the Golang implementation of the **waPC** standard for WebAssembly host 
 
 ## Example
 
-The following is a simple example of synchronous, bi-directional procedure calls between a WebAssembly host runtime and the guest module.
+The following is a simple example of synchronous, bidirectional procedure calls between a WebAssembly host runtime and the guest module.
 
 ```go
 package main
@@ -16,7 +16,7 @@ import (
 	"strings"
 
 	"github.com/wapc/wapc-go"
-	"github.com/wapc/wapc-go/engines/wasmer"
+	"github.com/wapc/wapc-go/engines/wazero"
 )
 
 func main() {
@@ -31,7 +31,7 @@ func main() {
 		panic(err)
 	}
 
-	engine := wasmer.Engine()
+	engine := wazero.Engine()
 
 	module, err := engine.New(ctx, code, hostCall)
 	if err != nil {
@@ -108,17 +108,49 @@ Alternatively you can use a `Pool` to manage a pool of instances.
 	}
 ```
 
-While the above example uses Wasmer, wapc-go is decoupled (via `wapc.Engine`) and can be used with different runtimes.
+While the above example uses wazero, wapc-go is decoupled (via [`wapc.Engine`](#engines)) and can be used with different runtimes.
 
 ## Engines
 
 Here are the supported `wapc.Engine` implementations, in alphabetical order:
 
-| Name        | Usage             | Package |
-|:-----------:|:-----------------:|:-------:|
-| wasmer-go   |`wasmer.Engine()`  |[github.com/wasmerio/wasmer-go](https://pkg.go.dev/github.com/wasmerio/wasmer-go)|
-| wasmtime-go |`wasmtime.Engine()`|[github.com/bytecodealliance/wasmtime-go](https://pkg.go.dev/github.com/bytecodealliance/wasmtime-go)|
-| wazero      |`wazero.Engine()`  |[github.com/tetratelabs/wazero](https://wazero.io)|
+|    Name     |        Usage        | Build Tag |                                                Package                                                |
+|:-----------:|:-------------------:|-----------|:-----------------------------------------------------------------------------------------------------:|
+|  wasmer-go  |  `wasmer.Engine()`  | wasmer    |           [github.com/wasmerio/wasmer-go](https://pkg.go.dev/github.com/wasmerio/wasmer-go)           |
+| wasmtime-go | `wasmtime.Engine()` | wasmtime  | [github.com/bytecodealliance/wasmtime-go](https://pkg.go.dev/github.com/bytecodealliance/wasmtime-go) |
+|   wazero    |  `wazero.Engine()`  | N/A       |                          [github.com/tetratelabs/wazero](https://wazero.io)                           |
+
+
+For example, to switch the engine to wasmer, change [example/main.go](example/main.go) like below:
+```diff
+--- a/example/main.go
++++ b/example/main.go
+@@ -7,7 +7,7 @@ import (
+        "strings"
+
+        "github.com/wapc/wapc-go"
+-       "github.com/wapc/wapc-go/engines/wazero"
++       "github.com/wapc/wapc-go/engines/wasmer"
+ )
+
+ func main() {
+@@ -22,7 +22,7 @@ func main() {
+                panic(err)
+        }
+
+-       engine := wazero.Engine()
++       engine := wasmer.Engine()
+
+        module, err := engine.New(ctx, code, hostCall)
+        if err != nil {
+```
+
+Then, run with its build tag:
+```bash
+$ go run --tags wasmer example/main.go waPC!
+hello called
+Hello, WaPC!
+```
 
 ### Differences with [wapc-rs](https://github.com/wapc/wapc-rs) (Rust)
 

--- a/engines/wasmer/wasmer.go
+++ b/engines/wasmer/wasmer.go
@@ -1,3 +1,5 @@
+//go:build (amd64 || arm64) && !windows && cgo && !wasmtime
+
 package wasmer
 
 import (

--- a/engines/wasmtime/wasmtime.go
+++ b/engines/wasmtime/wasmtime.go
@@ -1,3 +1,5 @@
+//go:build (((amd64 || arm64) && !windows) || (amd64 && windows)) && cgo && !wasmer
+
 package wasmtime
 
 import (

--- a/engines/wazero/wazero.go
+++ b/engines/wazero/wazero.go
@@ -115,7 +115,7 @@ func (e *engine) New(ctx context.Context, source []byte, hostCallHandler wapc.Ho
 	m := &Module{runtime: r, wapcHostCallHandler: hostCallHandler}
 	m.config = wazero.NewModuleConfig().
 		WithStartFunctions(functionStart, functionInit). // Call any WASI or waPC start functions on instantiate.
-		WithStdout(&stdout{m}) // redirect Stdout to the logger
+		WithStdout(&stdout{m})                           // redirect Stdout to the logger
 	mod = m
 
 	if _, err = wasi.InstantiateSnapshotPreview1(ctx, r); err != nil {

--- a/example/main.go
+++ b/example/main.go
@@ -2,59 +2,27 @@ package main
 
 import (
 	"context"
-	"flag"
 	"fmt"
-	"log"
 	"os"
 	"strings"
 
 	"github.com/wapc/wapc-go"
-	"github.com/wapc/wapc-go/engines/wasmtime"
+	"github.com/wapc/wapc-go/engines/wazero"
 )
 
-type Settings struct {
-	ModulePath   string
-	WaPCFunction string
-	Message      string
-}
-
-func cli() Settings {
-	var modulePath, wapcFunction string
-
-	flag.StringVar(&modulePath, "m", "", "Path to the Wasm module to be loaded")
-	flag.StringVar(&wapcFunction, "f", "echo", "Name of the waPC function to invoke")
-
-	flag.Parse()
-	if modulePath == "" {
-		os.Stderr.WriteString("Must provide path to the Wasm module to load")
-		flag.PrintDefaults()
-		os.Exit(1)
-	}
-
-	if flag.NArg() == 0 {
-		os.Stderr.WriteString("Must provide payload message for waPC function")
-		flag.PrintDefaults()
-		os.Exit(1)
-	}
-	msg := flag.Arg(0)
-
-	return Settings{
-		ModulePath:   modulePath,
-		Message:      msg,
-		WaPCFunction: wapcFunction,
-	}
-}
-
 func main() {
-	settings := cli()
-
+	if len(os.Args) < 2 {
+		fmt.Println("usage: hello <name>")
+		return
+	}
+	name := os.Args[1]
 	ctx := context.Background()
-	code, err := os.ReadFile(settings.ModulePath)
+	code, err := os.ReadFile("hello/hello.wasm")
 	if err != nil {
 		panic(err)
 	}
 
-	engine := wasmtime.Engine()
+	engine := wazero.Engine()
 
 	module, err := engine.New(ctx, code, hostCall)
 	if err != nil {
@@ -70,7 +38,7 @@ func main() {
 	}
 	defer instance.Close(ctx)
 
-	result, err := instance.Invoke(ctx, settings.WaPCFunction, []byte(settings.Message))
+	result, err := instance.Invoke(ctx, "hello", []byte(name))
 	if err != nil {
 		panic(err)
 	}
@@ -78,12 +46,7 @@ func main() {
 	fmt.Println(string(result))
 }
 
-func hostCall(_ context.Context, binding, namespace, operation string, payload []byte) ([]byte, error) {
-	log.Println("host callback")
-	log.Printf("binding: %s\n", binding)
-	log.Printf("namespace: %s\n", namespace)
-	log.Printf("operation: %s\n", operation)
-	log.Printf("payload: %s\n", string(payload))
+func hostCall(ctx context.Context, binding, namespace, operation string, payload []byte) ([]byte, error) {
 	// Route the payload to any custom functionality accordingly.
 	// You can even route to other waPC modules!!!
 	switch namespace {
@@ -93,11 +56,6 @@ func hostCall(_ context.Context, binding, namespace, operation string, payload [
 			name := string(payload)
 			name = strings.Title(name)
 			return []byte(name), nil
-		}
-	case "testing":
-		switch operation {
-		case "echo":
-			return []byte(fmt.Sprintf("echo: %s", payload)), nil // echo
 		}
 	}
 	return []byte("default"), nil

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,6 @@ go 1.17
 require (
 	github.com/Workiva/go-datastructures v1.0.53
 	github.com/bytecodealliance/wasmtime-go v0.35.0
-	github.com/tetratelabs/wazero v0.0.0-20220519192423-b3fc76ed6eb4
+	github.com/tetratelabs/wazero v0.0.0-20220523092326-5ed31d3c495d
 	github.com/wasmerio/wasmer-go v1.0.4
 )

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/tetratelabs/wazero v0.0.0-20220519192423-b3fc76ed6eb4 h1:mwKIDiHhIoHiEDbC072ZiWe+ybhn5NkcYLti4y5ENng=
-github.com/tetratelabs/wazero v0.0.0-20220519192423-b3fc76ed6eb4/go.mod h1:Y4X/zO4sC2dJjZG9GDYNRbJGogfqFYJY/BbyKlOxXGI=
+github.com/tetratelabs/wazero v0.0.0-20220523092326-5ed31d3c495d h1:OVaIrGwhWWvBsztdGYShF5XQUrf+n3d4rsEahI4NahI=
+github.com/tetratelabs/wazero v0.0.0-20220523092326-5ed31d3c495d/go.mod h1:Y4X/zO4sC2dJjZG9GDYNRbJGogfqFYJY/BbyKlOxXGI=
 github.com/tinylib/msgp v1.1.5/go.mod h1:eQsjooMTnV42mHu917E26IogZ2930nFyBQdofk10Udg=
 github.com/ttacon/chalk v0.0.0-20160626202418-22c06c80ed31/go.mod h1:onvgF043R+lC5RZ8IT9rBXDaEDnpnw/Cl+HFiw+v/7Q=
 github.com/wasmerio/wasmer-go v1.0.4 h1:MnqHoOGfiQ8MMq2RF6wyCeebKOe84G88h5yv+vmxJgs=


### PR DESCRIPTION
The CGO implementations (wasmer and wasmtime) clash on how they
implement WASI due to a flat namespace. This adjusts the build tags
accordingly.

This also consolidates the example code which drifted recently. Before,
it used different code in the README and the example/main.go and even
different runtimes. Instead, this uses wazero which has no source of
conflicts, but also documents how to change the runtime to any supported
engine.

Fixes #26