### PR TITLE
Updates to supported Go version and wazero beta

### DIFF
--- a/engines/wazero/wazero.go
+++ b/engines/wazero/wazero.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/tetratelabs/wazero"
 	"github.com/tetratelabs/wazero/api"
-	"github.com/tetratelabs/wazero/assemblyscript"
-	"github.com/tetratelabs/wazero/wasi_snapshot_preview1"
+	"github.com/tetratelabs/wazero/imports/assemblyscript"
+	"github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1"
 
 	"github.com/wapc/wapc-go"
 )
@@ -24,6 +24,7 @@ const functionStart = "_start"
 const functionInit = "wapc_init"
 
 // functionGuestCall is a callback required to be exported. Below is its signature in WebAssembly 1.0 (MVP) Text Format:
+//
 //	(func $__guest_call (param $operation_len i32) (param $payload_len i32) (result (;errno;) i32))
 const functionGuestCall = "__guest_call"
 
@@ -157,9 +158,9 @@ type wapcHost struct {
 }
 
 // instantiateWapcHost instantiates a wapcHost and returns it and its corresponding module, or an error.
-//	 - r: used to instantiate the waPC host module
-//	 - callHandler: used to implement hostCall
-//	 - logger: used to implement consoleLog
+//   - r: used to instantiate the waPC host module
+//   - callHandler: used to implement hostCall
+//   - logger: used to implement consoleLog
 func instantiateWapcHost(ctx context.Context, r wazero.Runtime, callHandler wapc.HostCallHandler, logger wapc.Logger) (api.Module, error) {
 	h := &wapcHost{callHandler: callHandler, logger: logger}
 	// Export host functions (in the order defined in https://wapc.io/docs/spec/#required-host-exports)

--- a/engines/wazero/wazero_test.go
+++ b/engines/wazero/wazero_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/tetratelabs/wazero"
-	"github.com/tetratelabs/wazero/wasi_snapshot_preview1"
+	"github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1"
 
 	"github.com/wapc/wapc-go"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,11 @@
 module github.com/wapc/wapc-go
 
-go 1.17
+go 1.18
 
 require (
 	github.com/Workiva/go-datastructures v1.0.53
 	github.com/bytecodealliance/wasmtime-go v0.39.0
-	github.com/tetratelabs/wazero v0.0.0-20220818123113-1948909ec0b1
+	github.com/tetratelabs/wazero v1.0.0-beta.2
 	github.com/wasmerio/wasmer-go v1.0.4
 )
 

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/tetratelabs/wazero v0.0.0-20220818123113-1948909ec0b1 h1:TjQhlrtayR+3VpwtMbxjXhGxRmNcdMUQn4eFUoFfkWs=
-github.com/tetratelabs/wazero v0.0.0-20220818123113-1948909ec0b1/go.mod h1:CD5smBN5rGZo7UNe8aUiWyYE3bDWED/CQSonog9NSEg=
+github.com/tetratelabs/wazero v1.0.0-beta.2 h1:Qa1R1oizAYHcmy8PljgINdXUZ/nRQkxUBbYfGSb4IBE=
+github.com/tetratelabs/wazero v1.0.0-beta.2/go.mod h1:CD5smBN5rGZo7UNe8aUiWyYE3bDWED/CQSonog9NSEg=
 github.com/tinylib/msgp v1.1.5/go.mod h1:eQsjooMTnV42mHu917E26IogZ2930nFyBQdofk10Udg=
 github.com/ttacon/chalk v0.0.0-20160626202418-22c06c80ed31/go.mod h1:onvgF043R+lC5RZ8IT9rBXDaEDnpnw/Cl+HFiw+v/7Q=
 github.com/wasmerio/wasmer-go v1.0.4 h1:MnqHoOGfiQ8MMq2RF6wyCeebKOe84G88h5yv+vmxJgs=


### PR DESCRIPTION
This updates [wazero](https://wazero.io) to 1.0.0-beta.2

Future betas will release at least once each month until 1.0 in February 2023.

Note: [Release notes](https://github.com/tetratelabs/wazero/releases) will be posted in the next day or two.

Meanwhile, we've also opened a [gophers slack](https://gophers.slack.com/) `#wazero` channel for support, updates and conversation! Note: You may need an [invite](https://invite.slack.golangbridge.org/) to join gophers.
