### PR TITLE
Adds ability to customize and access engine-specific types

### DIFF
--- a/engines/wasmer/example_test.go
+++ b/engines/wasmer/example_test.go
@@ -1,0 +1,30 @@
+package wasmer
+
+import (
+	"context"
+	"log"
+
+	"github.com/wasmerio/wasmer-go/wasmer"
+
+	"github.com/wapc/wapc-go"
+)
+
+// This shows how to customize the underlying wasmer engine used by waPC.
+func Example_custom() {
+	// Set up the context used to instantiate the engine.
+	ctx := context.Background()
+
+	// Configure waPC to use a specific wasmer feature.
+	e := Engine(WithEngine(func() *wasmer.Engine {
+		return wasmer.NewEngineWithConfig(wasmer.NewConfig().UseDylibEngine())
+	}))
+
+	// Instantiate a module normally.
+	m, err := e.New(ctx, wapc.NoOpHostCallHandler, guest, mc)
+	if err != nil {
+		log.Panicf("Error creating module - %v\n", err)
+	}
+	defer m.Close(ctx)
+
+	// Output:
+}

--- a/engines/wasmer/wasmer_test.go
+++ b/engines/wasmer/wasmer_test.go
@@ -1,0 +1,94 @@
+package wasmer
+
+import (
+	"context"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/wasmerio/wasmer-go/wasmer"
+
+	"github.com/wapc/wapc-go"
+)
+
+// testCtx is an arbitrary, non-default context. Non-nil also prevents linter errors.
+var testCtx = context.WithValue(context.Background(), struct{}{}, "arbitrary")
+
+var guest []byte
+var mc = &wapc.ModuleConfig{
+	Logger: wapc.PrintlnLogger,
+	Stdout: os.Stdout,
+	Stderr: os.Stderr,
+}
+
+// TestMain ensures we can read the example wasm prior to running unit tests.
+func TestMain(m *testing.M) {
+	var err error
+	guest, err = os.ReadFile("../../testdata/go/hello.wasm")
+	if err != nil {
+		log.Panicln(err)
+	}
+	os.Exit(m.Run())
+}
+
+func TestEngine_WithEngine(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
+		expected := wasmer.NewEngine()
+
+		e := Engine(WithEngine(func() *wasmer.Engine { return expected }))
+
+		m, err := e.New(testCtx, wapc.NoOpHostCallHandler, guest, mc)
+		if err != nil {
+			t.Errorf("Error creating module - %v", err)
+		}
+		defer m.Close(testCtx)
+
+		if have := m.(*Module).engine; have != expected {
+			t.Errorf("Unexpected engine, have %v, expected %v", have, expected)
+		}
+	})
+
+	t.Run("nil not ok", func(t *testing.T) {
+		expectedErr := "function set by WithEngine returned nil"
+
+		e := Engine(WithEngine(func() *wasmer.Engine { return nil }))
+
+		if _, err := e.New(testCtx, wapc.NoOpHostCallHandler, guest, mc); err.Error() != expectedErr {
+			t.Errorf("Unexpected error, have %v, expected %v", err, expectedErr)
+		}
+	})
+}
+
+func TestModule_Unwrap(t *testing.T) {
+	m, err := Engine().New(testCtx, wapc.NoOpHostCallHandler, guest, mc)
+	if err != nil {
+		t.Errorf("Error creating module - %v", err)
+	}
+	defer m.Close(testCtx)
+
+	mod := m.(*Module)
+	expected := mod.module
+	if have := mod.Unwrap(); have != expected {
+		t.Errorf("Unexpected module, have %v, expected %v", have, expected)
+	}
+}
+
+func TestInstance_Unwrap(t *testing.T) {
+	m, err := Engine().New(testCtx, wapc.NoOpHostCallHandler, guest, mc)
+	if err != nil {
+		t.Errorf("Error creating module - %v", err)
+	}
+	defer m.Close(testCtx)
+
+	i, err := m.Instantiate(testCtx)
+	if err != nil {
+		t.Errorf("Error creating instance - %v", err)
+	}
+	defer m.Close(testCtx)
+
+	inst := i.(*Instance)
+	expected := inst.inst
+	if have := inst.Unwrap(); have != expected {
+		t.Errorf("Unexpected instance, have %v, expected %v", have, expected)
+	}
+}

--- a/testdata/go/main.go
+++ b/testdata/go/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+
 	wapc "github.com/wapc/wapc-guest-tinygo"
 )
 


### PR DESCRIPTION
This allows end-users to use new features added compatibly to an engine without updating waPC first. This also allows generic use of engine-specific features without having to copy/paste tests in the underlying library.

This begins with wasmer, as that what was needed by #40