### PR TITLE
wazero: updates to 1.0.0-pre.2

### DIFF
--- a/engines/wazero/wazero.go
+++ b/engines/wazero/wazero.go
@@ -96,8 +96,7 @@ func (e *engine) Name() string {
 // DefaultRuntime implements NewRuntime by returning a wazero runtime with WASI
 // and AssemblyScript host functions instantiated.
 func DefaultRuntime(ctx context.Context) (wazero.Runtime, error) {
-	rc := wazero.NewRuntimeConfig().WithWasmCore2()
-	r := wazero.NewRuntimeWithConfig(ctx, rc)
+	r := wazero.NewRuntime(ctx)
 
 	if _, err := wasi_snapshot_preview1.Instantiate(ctx, r); err != nil {
 		_ = r.Close(ctx)
@@ -105,7 +104,7 @@ func DefaultRuntime(ctx context.Context) (wazero.Runtime, error) {
 	}
 
 	// This disables the abort message as no other engines write it.
-	envBuilder := r.NewModuleBuilder("env")
+	envBuilder := r.NewHostModuleBuilder("env")
 	assemblyscript.NewFunctionExporter().WithAbortMessageDisabled().ExportFunctions(envBuilder)
 	if _, err := envBuilder.Instantiate(ctx, r); err != nil {
 		_ = r.Close(ctx)
@@ -139,7 +138,7 @@ func (e *engine) New(ctx context.Context, host wapc.HostCallHandler, guest []byt
 		return
 	}
 
-	if m.compiled, err = r.CompileModule(ctx, guest, wazero.NewCompileConfig()); err != nil {
+	if m.compiled, err = r.CompileModule(ctx, guest); err != nil {
 		_ = r.Close(ctx)
 		return
 	}
@@ -164,7 +163,7 @@ type wapcHost struct {
 func instantiateWapcHost(ctx context.Context, r wazero.Runtime, callHandler wapc.HostCallHandler, logger wapc.Logger) (api.Module, error) {
 	h := &wapcHost{callHandler: callHandler, logger: logger}
 	// Export host functions (in the order defined in https://wapc.io/docs/spec/#required-host-exports)
-	return r.NewModuleBuilder("wapc").
+	return r.NewHostModuleBuilder("wapc").
 		ExportFunction("__host_call", h.hostCall,
 			"__host_call", "bind_ptr", "bind_len", "ns_ptr", "ns_len", "cmd_ptr", "cmd_len", "payload_ptr", "payload_len").
 		ExportFunction("__console_log", h.consoleLog,

--- a/engines/wazero/wazero_test.go
+++ b/engines/wazero/wazero_test.go
@@ -35,8 +35,7 @@ func TestMain(m *testing.M) {
 
 func TestEngineWithRuntime(t *testing.T) {
 	t.Run("instantiates custom runtime", func(t *testing.T) {
-		rc := wazero.NewRuntimeConfig().WithWasmCore2()
-		r := wazero.NewRuntimeWithConfig(testCtx, rc)
+		r := wazero.NewRuntime(testCtx)
 		defer r.Close(testCtx)
 
 		if _, err := wasi_snapshot_preview1.Instantiate(testCtx, r); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,6 @@ go 1.18
 require (
 	github.com/Workiva/go-datastructures v1.0.53
 	github.com/bytecodealliance/wasmtime-go v1.0.0
-	github.com/tetratelabs/wazero v1.0.0-pre.1
+	github.com/tetratelabs/wazero v1.0.0-pre.2
 	github.com/wasmerio/wasmer-go v1.0.4
 )

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
-github.com/tetratelabs/wazero v1.0.0-pre.1 h1:bUZ4vf21c36RmgA3enNOlLgPElEVDYoRJJ9+McRGF6Q=
-github.com/tetratelabs/wazero v1.0.0-pre.1/go.mod h1:M8UDNECGm/HVjOfq0EOe4QfCY9Les1eq54IChMLETbc=
+github.com/tetratelabs/wazero v1.0.0-pre.2 h1:sHYi8DKUL7s7c4sKz6lw0pNqky5EogYK0Iq4pSIsDog=
+github.com/tetratelabs/wazero v1.0.0-pre.2/go.mod h1:M8UDNECGm/HVjOfq0EOe4QfCY9Les1eq54IChMLETbc=
 github.com/tinylib/msgp v1.1.5/go.mod h1:eQsjooMTnV42mHu917E26IogZ2930nFyBQdofk10Udg=
 github.com/ttacon/chalk v0.0.0-20160626202418-22c06c80ed31/go.mod h1:onvgF043R+lC5RZ8IT9rBXDaEDnpnw/Cl+HFiw+v/7Q=
 github.com/wasmerio/wasmer-go v1.0.4 h1:MnqHoOGfiQ8MMq2RF6wyCeebKOe84G88h5yv+vmxJgs=


### PR DESCRIPTION
This updates [wazero](https://wazero.io/) to [1.0.0-pre.2](https://github.com/tetratelabs/wazero/releases/tag/v1.0.0-pre.2).

Notably, this simplifies syntax for some common cases.