### PR TITLE
deps: updates wazero and wastime to latest

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,7 +18,7 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.29
+          version: v1.50.1
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir

--- a/example/main.go
+++ b/example/main.go
@@ -56,7 +56,7 @@ func host(_ context.Context, binding, namespace, operation string, payload []byt
 		switch operation {
 		case "capitalize":
 			name := string(payload)
-			name = strings.Title(name)
+			name = strings.Title(name) // nolint
 			return []byte(name), nil
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,6 @@ go 1.18
 require (
 	github.com/Workiva/go-datastructures v1.0.53
 	github.com/bytecodealliance/wasmtime-go v1.0.0
-	github.com/tetratelabs/wazero v1.0.0-pre.3
+	github.com/tetratelabs/wazero v1.0.0-pre.4
 	github.com/wasmerio/wasmer-go v1.0.4
 )

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
-github.com/tetratelabs/wazero v1.0.0-pre.3 h1:Z5fbogMUGcERzaQb9mQU8+yJSy0bVvv2ce3dfR4wcZg=
-github.com/tetratelabs/wazero v1.0.0-pre.3/go.mod h1:M8UDNECGm/HVjOfq0EOe4QfCY9Les1eq54IChMLETbc=
+github.com/tetratelabs/wazero v1.0.0-pre.4 h1:RBJQT5OzmORkSp6MmZDWoFEr0zXjk4pmvMKAdeUnsaI=
+github.com/tetratelabs/wazero v1.0.0-pre.4/go.mod h1:u8wrFmpdrykiFK0DFPiFm5a4+0RzsdmXYVtijBKqUVo=
 github.com/tinylib/msgp v1.1.5/go.mod h1:eQsjooMTnV42mHu917E26IogZ2930nFyBQdofk10Udg=
 github.com/ttacon/chalk v0.0.0-20160626202418-22c06c80ed31/go.mod h1:onvgF043R+lC5RZ8IT9rBXDaEDnpnw/Cl+HFiw+v/7Q=
 github.com/wasmerio/wasmer-go v1.0.4 h1:MnqHoOGfiQ8MMq2RF6wyCeebKOe84G88h5yv+vmxJgs=

--- a/hello/go.mod
+++ b/hello/go.mod
@@ -2,4 +2,4 @@ module github.com/wapc/wapc-go/hello
 
 go 1.17
 
-require github.com/wapc/wapc-guest-tinygo v0.3.2
+require github.com/wapc/wapc-guest-tinygo v0.3.3

--- a/hello/go.sum
+++ b/hello/go.sum
@@ -1,2 +1,2 @@
-github.com/wapc/wapc-guest-tinygo v0.3.2 h1:b9zkLL+44dxL8MWjZmdG6XAcO6ITK5Xzgok0eKzu/vY=
-github.com/wapc/wapc-guest-tinygo v0.3.2/go.mod h1:mzM3CnsdSYktfPkaBdZ8v88ZlfUDEy5Jh5XBOV3fYcw=
+github.com/wapc/wapc-guest-tinygo v0.3.3 h1:jLebiwjVSHLGnS+BRabQ6+XOV7oihVWAc05Hf1SbeR0=
+github.com/wapc/wapc-guest-tinygo v0.3.3/go.mod h1:mzM3CnsdSYktfPkaBdZ8v88ZlfUDEy5Jh5XBOV3fYcw=

--- a/testdata/go/go.mod
+++ b/testdata/go/go.mod
@@ -2,4 +2,4 @@ module github.com/wapc/wapc-go/testdata/go
 
 go 1.17
 
-require github.com/wapc/wapc-guest-tinygo v0.3.2
+require github.com/wapc/wapc-guest-tinygo v0.3.3

--- a/testdata/go/go.sum
+++ b/testdata/go/go.sum
@@ -1,2 +1,2 @@
-github.com/wapc/wapc-guest-tinygo v0.3.2 h1:b9zkLL+44dxL8MWjZmdG6XAcO6ITK5Xzgok0eKzu/vY=
-github.com/wapc/wapc-guest-tinygo v0.3.2/go.mod h1:mzM3CnsdSYktfPkaBdZ8v88ZlfUDEy5Jh5XBOV3fYcw=
+github.com/wapc/wapc-guest-tinygo v0.3.3 h1:jLebiwjVSHLGnS+BRabQ6+XOV7oihVWAc05Hf1SbeR0=
+github.com/wapc/wapc-guest-tinygo v0.3.3/go.mod h1:mzM3CnsdSYktfPkaBdZ8v88ZlfUDEy5Jh5XBOV3fYcw=


### PR DESCRIPTION
This updates [wazero](https://wazero.io/) to [1.0.0-pre.4](https://github.com/tetratelabs/wazero/releases/tag/v1.0.0-pre.4).

Notably, v1.0.0-pre.4:
* improves module initialization speed
* supports listeners in the compiler engine
* supports WASI `fd_pread`, `fd_readdir` and `path_filestat_get`
* breaks GoModuleFunc API

There are no release notes for wasmtime, but here is the diff https://github.com/bytecodealliance/wasmtime-go/compare/v1.0.0...v3.0.2