### PR TITLE
Removes context parameter to MemorySize and updates runtimes.

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -50,7 +50,7 @@ type (
 	// Instance is an instantiated Module
 	Instance interface {
 		// MemorySize is the size in bytes of the memory available to this Instance.
-		MemorySize(context.Context) uint32
+		MemorySize() uint32
 
 		// Invoke calls `operation` with `payload` on the module and returns a byte slice payload.
 		Invoke(ctx context.Context, operation string, payload []byte) ([]byte, error)

--- a/engine_test.go
+++ b/engine_test.go
@@ -152,8 +152,8 @@ func TestModule(t *testing.T) {
 			t.Run("Check MemorySize", func(t *testing.T) {
 				// Verify implementations didn't mistake size in bytes for page count.
 				expectedMemorySize := uint32(65536) // 1 page
-				if i.MemorySize(ctx) != expectedMemorySize {
-					t.Errorf("Unexpected memory size, got %d, expected %d", i.MemorySize(ctx), expectedMemorySize)
+				if i.MemorySize() != expectedMemorySize {
+					t.Errorf("Unexpected memory size, got %d, expected %d", i.MemorySize(), expectedMemorySize)
 				}
 			})
 

--- a/engines/wasmer/wasmer.go
+++ b/engines/wasmer/wasmer.go
@@ -572,7 +572,7 @@ func (i *Instance) wasiRuntime() map[string]wasmer.IntoExtern {
 }
 
 // MemorySize returns the memory length of the underlying instance.
-func (i *Instance) MemorySize(context.Context) uint32 {
+func (i *Instance) MemorySize() uint32 {
 	return uint32(i.mem.DataSize())
 }
 

--- a/engines/wasmtime/wasmtime.go
+++ b/engines/wasmtime/wasmtime.go
@@ -425,7 +425,7 @@ func (i *Instance) wapcRuntime() map[string]*wasmtime.Func {
 }
 
 // MemorySize returns the memory length of the underlying instance.
-func (i *Instance) MemorySize(context.Context) uint32 {
+func (i *Instance) MemorySize() uint32 {
 	return uint32(i.mem.DataSize(i.m.store))
 }
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,6 @@ go 1.18
 require (
 	github.com/Workiva/go-datastructures v1.0.53
 	github.com/bytecodealliance/wasmtime-go v1.0.0
-	github.com/tetratelabs/wazero v1.0.0-pre.4
+	github.com/tetratelabs/wazero v1.0.0-pre.6
 	github.com/wasmerio/wasmer-go v1.0.4
 )

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
-github.com/tetratelabs/wazero v1.0.0-pre.4 h1:RBJQT5OzmORkSp6MmZDWoFEr0zXjk4pmvMKAdeUnsaI=
-github.com/tetratelabs/wazero v1.0.0-pre.4/go.mod h1:u8wrFmpdrykiFK0DFPiFm5a4+0RzsdmXYVtijBKqUVo=
+github.com/tetratelabs/wazero v1.0.0-pre.6 h1:3DRqjuHazHyZmgWCgqu7nKgYIYNEi2+2RQpCwTqbVHs=
+github.com/tetratelabs/wazero v1.0.0-pre.6/go.mod h1:u8wrFmpdrykiFK0DFPiFm5a4+0RzsdmXYVtijBKqUVo=
 github.com/tinylib/msgp v1.1.5/go.mod h1:eQsjooMTnV42mHu917E26IogZ2930nFyBQdofk10Udg=
 github.com/ttacon/chalk v0.0.0-20160626202418-22c06c80ed31/go.mod h1:onvgF043R+lC5RZ8IT9rBXDaEDnpnw/Cl+HFiw+v/7Q=
 github.com/wasmerio/wasmer-go v1.0.4 h1:MnqHoOGfiQ8MMq2RF6wyCeebKOe84G88h5yv+vmxJgs=


### PR DESCRIPTION
This removes the go context parameter from MemorySize. This was never used in practice due to the scope being very narrow, as well most memory affects happening inside native code.

This also updates runtime dependencies of wasmtime and wazero. Below are notes about wazero:

wazero [1.0.0-pre.6](https://github.com/tetratelabs/wazero/releases/tag/v1.0.0-pre.6):
* improves module compilation and initialization performance
* adds `writefs.NewDirFS` which lets you add new files.
  * `path_open` `O_CREAT` flags, `path_remove_directory` `path_rename` `path_unlink_file`
* adds `NewFilesystemLoggingListenerFactory` with dramatically improved logging.

Since the previous version was 1.0.0-pre.4, this also includes changes from [1.0.0-pre.5](https://github.com/tetratelabs/wazero/releases/tag/v1.0.0-pre.5).