### PR TITLE
deps: updates wazero to 1.0.0-pre.9

### DIFF
--- a/engines/wazero/wazero.go
+++ b/engines/wazero/wazero.go
@@ -107,7 +107,7 @@ func DefaultRuntime(ctx context.Context) (wazero.Runtime, error) {
 	// This disables the abort message as no other engines write it.
 	envBuilder := r.NewHostModuleBuilder("env")
 	assemblyscript.NewFunctionExporter().WithAbortMessageDisabled().ExportFunctions(envBuilder)
-	if _, err := envBuilder.Instantiate(ctx, r); err != nil {
+	if _, err := envBuilder.Instantiate(ctx); err != nil {
 		_ = r.Close(ctx)
 		return nil, err
 	}
@@ -205,7 +205,7 @@ func instantiateWapcHost(ctx context.Context, r wazero.Runtime, callHandler wapc
 		NewFunctionBuilder().
 		WithGoFunction(api.GoFunc(h.hostErrorLen), []api.ValueType{}, []api.ValueType{i32}).
 		Export("__host_error_len").
-		Instantiate(ctx, r)
+		Instantiate(ctx)
 }
 
 // hostCall is the WebAssembly function export "__host_call", which initiates a host using the callHandler using

--- a/engines/wazero/wazero_test.go
+++ b/engines/wazero/wazero_test.go
@@ -96,7 +96,8 @@ func TestEngineWithRuntime(t *testing.T) {
 
 		// We expect this to close the runtime returned by NewRuntime
 		m.Close(testCtx)
-		if _, err = r.InstantiateModuleFromBinary(testCtx, guest); err == nil {
+		// Ensure the runtime is now closed by invoking a related method
+		if mod := r.Module(wasi_snapshot_preview1.ModuleName); mod != nil {
 			t.Errorf("Expected Module.Close to close wazero Runtime")
 		}
 	})

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,6 @@ go 1.18
 require (
 	github.com/Workiva/go-datastructures v1.0.53
 	github.com/bytecodealliance/wasmtime-go v1.0.0
-	github.com/tetratelabs/wazero v1.0.0-pre.6
+	github.com/tetratelabs/wazero v1.0.0-pre.9
 	github.com/wasmerio/wasmer-go v1.0.4
 )

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
-github.com/tetratelabs/wazero v1.0.0-pre.6 h1:3DRqjuHazHyZmgWCgqu7nKgYIYNEi2+2RQpCwTqbVHs=
-github.com/tetratelabs/wazero v1.0.0-pre.6/go.mod h1:u8wrFmpdrykiFK0DFPiFm5a4+0RzsdmXYVtijBKqUVo=
+github.com/tetratelabs/wazero v1.0.0-pre.9 h1:2uVdi2bvTi/JQxG2cp3LRm2aRadd3nURn5jcfbvqZcw=
+github.com/tetratelabs/wazero v1.0.0-pre.9/go.mod h1:wYx2gNRg8/WihJfSDxA1TIL8H+GkfLYm+bIfbblu9VQ=
 github.com/tinylib/msgp v1.1.5/go.mod h1:eQsjooMTnV42mHu917E26IogZ2930nFyBQdofk10Udg=
 github.com/ttacon/chalk v0.0.0-20160626202418-22c06c80ed31/go.mod h1:onvgF043R+lC5RZ8IT9rBXDaEDnpnw/Cl+HFiw+v/7Q=
 github.com/wasmerio/wasmer-go v1.0.4 h1:MnqHoOGfiQ8MMq2RF6wyCeebKOe84G88h5yv+vmxJgs=


### PR DESCRIPTION
This updates [wazero](https://wazero.io/) to [1.0.0-pre.9][1]. Notably:

* This release includes our last breaking changes before 1.0.0 final:
  * Requires at least Go 1.8
* This release also integrates Go context to limit execution time.
  More details on the [Release Notes][1]
* We are now passing third-party integration test suites: wasi-testsuite,
  TinyGo's, Zig's.

This PR also includes changes required by [wazero](https://wazero.io/)
[1.0.0-pre.8][2]:

* Changes the `Instantiate` signature, which no longer requires
  an explicit `Runtime` instance.

[1]: https://github.com/tetratelabs/wazero/releases/tag/v1.0.0-pre.9
[2]: https://github.com/tetratelabs/wazero/releases/tag/v1.0.0-pre.8

Signed-off-by: Edoardo Vacchi <evacchi@users.noreply.github.com>