### PR TITLE
feat(hostcallDuringLoad): Allow updating the context with InvokeContext

### DIFF
--- a/engines/wazero/wazero_test.go
+++ b/engines/wazero/wazero_test.go
@@ -141,5 +141,4 @@ func TestEngineWithRuntime(t *testing.T) {
 			t.Errorf("Unexpected error, got %v, expected %v", err, expectedErr)
 		}
 	})
-
 }

--- a/engines/wazero/wazero_test.go
+++ b/engines/wazero/wazero_test.go
@@ -141,4 +141,5 @@ func TestEngineWithRuntime(t *testing.T) {
 			t.Errorf("Unexpected error, got %v, expected %v", err, expectedErr)
 		}
 	})
+
 }


### PR DESCRIPTION
wapc go 's wazero runtime allows web assembly modules to make host calls to request the host runtime to execute some tasks that web assembly is not capable of .
wapc 's host call is limited to the guest module's explicitly exported function that gets called during the invoke.
This PR allows the host to update with InvocationContext prior to wasm instantiation. This allows the wasm to perform hostcalls during the loading phase.

Value Added by this PR:
This PR is important because the wasm can now fetch environment variables during the instantiation phase while utilizing the benefits provided by wapc.

If there is a need to perform hostcalls from main, prior to instantiation of the wasm, a line of code is to be added :
m.ctx = wazero.AddInvokeContext(m.ctx)
