### PR TITLE
chore(ci): adding coverage reports

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -32,3 +32,8 @@ jobs:
 
     - name: Test
       run: make tests
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v3
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Adds codecov for reporting code coverage and ensuring code coverage is maintained with new PRs.

This will require setting up a repository secret with the codecov token, but the setup is pretty straightforward. If you'd like to use a different coverage provider, let me know, and I'll be happy to adjust it.

codecov is free for open source, so no costs are associated.